### PR TITLE
Remove coverlet.collector dependency

### DIFF
--- a/AdventOfCodeTests/AdventOfCodeTests.csproj
+++ b/AdventOfCodeTests/AdventOfCodeTests.csproj
@@ -9,7 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="10.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Stack
 
 - .NET 9.0, C# latest, Autofac DI
-- xUnit 2.x (test framework), xunit.runner.visualstudio, Microsoft.NET.Test.Sdk, coverlet.collector
+- xUnit 2.x (test framework), xunit.runner.visualstudio, Microsoft.NET.Test.Sdk
 
 ## Build & Test
 


### PR DESCRIPTION
## Summary
- Drops the `coverlet.collector` NuGet package from `AdventOfCodeTests.csproj`.
- This is a local-only hobby repo; no CI workflow invokes `dotnet test --collect`, so the package was unused. Rider's bundled dotCover provides coverage on demand without it.
- Updates `CLAUDE.md` stack list to match.
- Supersedes #58 (Dependabot bump 10.0.0 → 10.0.1).

## Test plan
- [x] `dotnet build AdventOfCode.sln` — succeeds, 0 errors
- [x] `dotnet test AdventOfCodeTests/AdventOfCodeTests.csproj` — 182/182 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)